### PR TITLE
chore: nextjs 앱 라우터 설정 추가

### DIFF
--- a/apps/extensions/package.json
+++ b/apps/extensions/package.json
@@ -11,7 +11,7 @@
     "@it-diots/ui": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.1.7"
+    "next": "catalog:"
   },
   "devDependencies": {
     "@it-diots/eslint-config": "workspace:*",

--- a/apps/extensions/package.json
+++ b/apps/extensions/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@it-diots/ui": "workspace:*",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "next": "15.1.7"
   },
   "devDependencies": {
     "@it-diots/eslint-config": "workspace:*",

--- a/apps/extensions/src/App.tsx
+++ b/apps/extensions/src/App.tsx
@@ -1,11 +1,14 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button } from '@ui';
+import { useRouter } from 'next/navigation';
 
 export default function App() {
+  const { push } = useRouter();
+
   return (
     <div className="w-[400px] min-h-[300px] p-4">
       <h1 className="text-2xl font-bold mb-4">IT Diots Extension</h1>
 
-      <Button>Click me</Button>
+      <Button onClick={() => push('https://github.com/it-diots/it-diots')}>Click me</Button>
 
       <Accordion type="single" collapsible>
         <AccordionItem value="item-1">

--- a/apps/extensions/src/custom-router.ts
+++ b/apps/extensions/src/custom-router.ts
@@ -1,0 +1,29 @@
+import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+
+declare type Url = string;
+
+export default class CustomRouter implements AppRouterInstance {
+  back(): void {
+    window.history.back();
+  }
+
+  forward(): void {
+    window.history.forward();
+  }
+
+  refresh() {
+    window.location.reload();
+  }
+
+  push(url: Url): boolean {
+    window.location.href = url as string;
+    return true;
+  }
+
+  replace(url: Url): boolean {
+    window.location.href = url as string;
+    return true;
+  }
+
+  prefetch(): void {}
+}

--- a/apps/extensions/src/index.tsx
+++ b/apps/extensions/src/index.tsx
@@ -1,8 +1,18 @@
+import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import { createRoot } from 'react-dom/client';
-import '@it-diots/ui/globals.css';
+
 import App from './App';
+import CustomRouter from './custom-router';
+
+import '@it-diots/ui/globals.css';
+
+const router = new CustomRouter();
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Failed to find the root element');
 const root = createRoot(container);
-root.render(<App />);
+root.render(
+  <AppRouterContext.Provider value={router}>
+    <App />
+  </AppRouterContext.Provider>
+);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@it-diots/ui": "workspace:*",
     "@it-diots/supabase": "workspace:*",
-    "next": "15.1.7",
+    "next": "catalog:",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     lucide-react:
       specifier: ^0.294.0
       version: 0.294.0
+    next:
+      specifier: 15.1.7
+      version: 15.1.7
     prettier:
       specifier: ^3.2.5
       version: 3.5.1
@@ -60,7 +63,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: 15.1.7
+        specifier: 'catalog:'
         version: 15.1.7(@babel/core@7.26.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
@@ -115,7 +118,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: 15.1.7
+        specifier: 'catalog:'
         version: 15.1.7(@babel/core@7.26.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@it-diots/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      next:
+        specifier: 15.1.7
+        version: 15.1.7(@babel/core@7.26.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -113,7 +116,7 @@ importers:
         version: link:../../packages/ui
       next:
         specifier: 15.1.7
-        version: 15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.1.7(@babel/core@7.26.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -6522,7 +6525,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.1.7(@babel/core@7.26.9)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.1.7
       '@swc/counter': 0.1.3
@@ -6532,7 +6535,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      styled-jsx: 5.1.6(react@19.0.0)
+      styled-jsx: 5.1.6(@babel/core@7.26.9)(react@19.0.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.7
       '@next/swc-darwin-x64': 15.1.7
@@ -7197,10 +7200,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(react@19.0.0):
+  styled-jsx@5.1.6(@babel/core@7.26.9)(react@19.0.0):
     dependencies:
       client-only: 0.0.1
       react: 19.0.0
+    optionalDependencies:
+      '@babel/core': 7.26.9
 
   sucrase@3.35.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,5 +8,6 @@ catalog:
   eslint: ^8.57.0
   prettier: ^3.2.5
   typescript: ^5.3.3
+  next: 15.1.7
   '@types/node': ^20.11.24
   '@types/eslint': ^8.56.2


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)

> 작업 범위에 대해 간략하게 작성합니다.

- Next.js 내 라우터 기능을 커스터마이징 하여 호환성을 추가하는 작업을 진행했습니다.

## 📝 상세 설명

> 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

- `index.tsx` 파일(루트 렌더링 파일) 내 전체 앱을 `AppRouterContext` 로 감싸는 코드가 추가됩니다.
  - **Why?** 웹 앱 프로젝트와 익스텐션 프로젝트 내에서 공용으로 활용될 컴포넌트에서 `useRouter` 를 사용할 때 호환성을 유지하고자 적용한 설정입니다. 해당 작업을 통해 `useRouter`(`next/navigation`)가 React + Vite 프로젝트 내에서도 동작합니다. 
- 성공 여부는 익스텐션 프로젝트 개발 모드를 실행하고 버튼을 누르는 경우 라우팅 기능이 정상적으로 동작합니다.
  - `it-diots` 오가니제이션으로 이동

## ⚙️ 기타 사항

> PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

- `extensions` 워크스페이스 내 `next` 패키지가 추가됩니다.
- `next` 패키지 버전 `catalog` 추가
- 라우팅 처리를 할 때 **전체 경로**를 입력해야 합니다. 자세한 내용은 화요일에 공유드리겠습니다.

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [x] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?
