### PR TITLE
fix: Supabase type generator 추가

### DIFF
--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -4,18 +4,19 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "gen-type": "supabase gen types typescript --project-id tvdhvlmxynbiazmrngix --schema public > ./src/types/supabase.ts"
   },
   "peerDependencies": {
     "next": "15.1.7"
   },
   "devDependencies": {
-    "typescript": "catalog"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.48.1",
-    "supabase": "^1.226.4"
+    "supabase": "^2.12.1"
   },
   "exports": {
     "./client": {

--- a/packages/supabase/src/types/index.ts
+++ b/packages/supabase/src/types/index.ts
@@ -1,2 +1,9 @@
 /** 추후 Supabase의 OAuth 기능 추가시 사용  */
 export { type Provider } from '@supabase/supabase-js';
+
+import { Database } from './supabase';
+
+/** supabase.ts 사용 예제 */
+type TodoInfo = Database['public']['Tables']['todo-temp']['Row'];
+
+export type { TodoInfo };

--- a/packages/supabase/src/types/supabase.ts
+++ b/packages/supabase/src/types/supabase.ts
@@ -1,0 +1,144 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      "todo-temp": {
+        Row: {
+          createdAt: string | null
+          deletedAt: string | null
+          id: number
+          todo: string | null
+        }
+        Insert: {
+          createdAt?: string | null
+          deletedAt?: string | null
+          id?: number
+          todo?: string | null
+        }
+        Update: {
+          createdAt?: string | null
+          deletedAt?: string | null
+          id?: number
+          todo?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,11 +236,11 @@ importers:
         specifier: 15.1.7
         version: 15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       supabase:
-        specifier: ^1.226.4
-        version: 1.226.4
+        specifier: ^2.12.1
+        version: 2.12.1
     devDependencies:
       typescript:
-        specifier: ^5.5.4
+        specifier: 'catalog:'
         version: 5.7.3
 
   packages/typescript-config: {}
@@ -3435,8 +3435,8 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
-  supabase@1.226.4:
-    resolution: {integrity: sha512-qEzoagrqZs5T7sAlfZzehX3PJ13cSBrJVs2vrh6xC+B0VI0wgOBw2gCNRcsOMJMpSr0V1l0XueCiFBWPm2U03w==}
+  supabase@2.12.1:
+    resolution: {integrity: sha512-vB6LX1KGrqku8AFlp2vJw49IUB9g6Rz2b84qpcWSZ3mMDFumA6hDSbXbFJUnr3hcvyPzoOsQlhMTZN7a6o3hfA==}
     engines: {npm: '>=8'}
     hasBin: true
 
@@ -7212,7 +7212,7 @@ snapshots:
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
 
-  supabase@1.226.4:
+  supabase@2.12.1:
     dependencies:
       bin-links: 5.0.0
       https-proxy-agent: 7.0.6


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)
- `Supabase`에서 지원하는 `Table`에 맞춰 타입 파일을 생성해주는 실행 스크립트 추가, 파일 추가

## 📝 상세 설명
- 이전 `PR`에서 `catalog` 오타가 있어 수정했습니다. (`catalog` -> `catalog:`)

- `gen-type`명령어로 `Supabase`에서 명시한 `Table`의 타입에 맞춰 타입이 생성됩니다.

- 사용 예제만 간단하게 추가했고, '어떻게 타입을 `export` 할 것인지?'에 대해선 논의가 필요합니다.

- 파일 위치는 임의로 두었는데, `types > index.ts, supabse.ts(신규)`로 `supabse.ts`에서의 타입을 `index.ts`에서 조합해 모듈로 사용하는 것도 괜찮아 보입니다.

- 새로운 필드 추가하고, `pnpm gen-type` 명령어 실행 후 `supabse.ts`가 잘 업데이트 되는지 확인 완료했습니다.

## 🚨 Merge 전 필요 작업 (Checklist before merge)

- [ ] 컨벤션에 맞는 코드를 작성했나요?
- [x] 로컬 빌드시 에러가 발생하지 않았나요?

<img width="240" alt="image" src="https://github.com/user-attachments/assets/fe334f38-b6e1-4aa9-8d4e-eb0c09f5cd3e" />
